### PR TITLE
修正: mainブランチのテストをワークフローと一致させる

### DIFF
--- a/test/workflow/test-workflow.test.ts
+++ b/test/workflow/test-workflow.test.ts
@@ -97,10 +97,10 @@ describe('Test Workflow', () => {
       expect(steps[5].run).toBe('npm run test:coverage')
     })
 
-    it('should deploy Windows coverage on push events', () => {
+    it('should deploy Windows coverage on push and workflow_dispatch events', () => {
       const deployStep = steps[6]
       expect(deployStep.name).toBe('Windows環境のカバレッジをGitHub Pagesにデプロイ')
-      expect(deployStep.if).toBe("matrix.os == 'windows-latest' && github.event_name == 'push'")
+      expect(deployStep.if).toBe("matrix.os == 'windows-latest' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')")
       expect(deployStep.uses).toBe('./')
     })
 


### PR DESCRIPTION
## 概要
mainブランチのワークフローでは、手動実行（workflow_dispatch）時もGitHub Pagesへのデプロイが有効になっていますが、テストがそれに対応していませんでした。

## 変更内容
- テストの期待値を更新して、pushとworkflow_dispatchの両方でデプロイされることを確認
- テスト名も「push and workflow_dispatch events」に更新

## テスト結果
- ✅ Ubuntu、macOSでテスト成功
- ✅ Windowsでテスト成功（デプロイステップは権限エラーで失敗するが、これは正常な動作）