### PR TITLE
feat: wrangler.jsonファイルのサポートを追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,8 @@ runs:
         # Install dependencies
         npm install
         
-        # Check if wrangler.toml exists
-        if [ -f wrangler.toml ]; then
+        # Check if wrangler.toml or wrangler.json exists
+        if [ -f wrangler.toml ] || [ -f wrangler.json ]; then
           echo "Wrangler configuration found, generating OpenAPI specification..."
           
           # Copy template for Wrangler
@@ -84,7 +84,7 @@ runs:
           kill $wranglerPID || true
           rm -f .dev.vars
         else
-          echo "No wrangler.toml found, skipping OpenAPI generation"
+          echo "No wrangler.toml or wrangler.json found, skipping OpenAPI generation"
           # Create docs directory if it doesn't exist
           mkdir -p docs
         fi
@@ -155,8 +155,8 @@ runs:
         # Install dependencies
         npm install
         
-        # Check if wrangler.toml exists
-        if (Test-Path wrangler.toml) {
+        # Check if wrangler.toml or wrangler.json exists
+        if ((Test-Path wrangler.toml) -or (Test-Path wrangler.json)) {
           Write-Host "Wrangler configuration found, generating OpenAPI specification..."
           
           # Copy template for Wrangler
@@ -192,7 +192,7 @@ runs:
           Start-Sleep -Seconds 2
           Remove-Item .dev.vars -Force -ErrorAction SilentlyContinue
         } else {
-          Write-Host "No wrangler.toml found, skipping OpenAPI generation"
+          Write-Host "No wrangler.toml or wrangler.json found, skipping OpenAPI generation"
           # Create docs directory if it doesn't exist
           New-Item -ItemType Directory -Path docs -Force | Out-Null
         }


### PR DESCRIPTION
## Summary
- wrangler.tomlだけでなくwrangler.jsonも検出してOpenAPI生成を実行するように修正
- Bash版とPowerShell版の両方に対応

## Test plan
- [ ] wrangler.jsonファイルがある場合にOpenAPI生成が実行されることを確認
- [ ] wrangler.tomlファイルがある場合に引き続き動作することを確認
- [ ] どちらのファイルもない場合にスキップされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)