### PR TITLE
fix: Wrangler起動失敗時でもデプロイを継続

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,8 +74,9 @@ runs:
               break
             fi
             if [ $i -eq $maxAttempts ]; then
-              echo "Wrangler failed to start"
-              exit 1
+              echo "Warning: Wrangler failed to start after $maxAttempts attempts"
+              echo "Continuing without OpenAPI specification..."
+              break
             fi
             sleep 2
           done
@@ -181,7 +182,11 @@ runs:
               Write-Host "OpenAPI specification generated"
               break
             } catch {
-              if ($i -eq $maxAttempts) { throw "Wrangler failed to start" }
+              if ($i -eq $maxAttempts) {
+                Write-Host "Warning: Wrangler failed to start after $maxAttempts attempts"
+                Write-Host "Continuing without OpenAPI specification..."
+                break
+              }
               Start-Sleep -Seconds 2
             }
           }

--- a/test/workflow/workflow-simulation.test.ts
+++ b/test/workflow/workflow-simulation.test.ts
@@ -148,8 +148,9 @@ describe('Workflow Simulation Tests', () => {
       const runContent = bashStep!.run!
 
       expect(runContent).toContain('if [ $i -eq $maxAttempts ]; then')
-      expect(runContent).toContain('echo "Wrangler failed to start"')
-      expect(runContent).toContain('exit 1')
+      expect(runContent).toContain('echo "Warning: Wrangler failed to start after $maxAttempts attempts"')
+      expect(runContent).toContain('echo "Continuing without OpenAPI specification..."')
+      expect(runContent).not.toContain('exit 1')
     })
 
     it('should validate cleanup happens even on failure', () => {
@@ -168,7 +169,10 @@ describe('Workflow Simulation Tests', () => {
       const powershellStep = validator.getStepByName('Process and Deploy (PowerShell)')
       const runContent = powershellStep!.run!
 
-      expect(runContent).toContain('if ($i -eq $maxAttempts) { throw "Wrangler failed to start" }')
+      expect(runContent).toContain('if ($i -eq $maxAttempts) {')
+      expect(runContent).toContain('Write-Host "Warning: Wrangler failed to start after $maxAttempts attempts"')
+      expect(runContent).toContain('Write-Host "Continuing without OpenAPI specification..."')
+      expect(runContent).not.toContain('throw "Wrangler failed to start"')
       expect(runContent).toContain('-ErrorAction SilentlyContinue')
       expect(runContent).toContain('Remove-Item -Recurse -Force $tempDir')
     })


### PR DESCRIPTION
## Summary
- Wrangler起動失敗時でも処理を継続してカバレッジレポートなどをデプロイできるよう修正
- エラーをfatalからwarningに変更

## Changes
- action.ymlでWrangler起動失敗時に`exit 1`や`throw`する代わりに警告を出して継続
- テストを更新してnon-blocking動作を期待するよう修正

## Test plan
- [x] すべてのテストがパス
- [ ] GitHub Actionsでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)