### PR TITLE
fix: orphanブランチを使用してpublicリポジトリへのAction履歴の漏洩を防止

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,14 +111,19 @@ runs:
         # Get original commit message
         ORIGINAL_MSG=$(git log -1 --pretty=%B)
         
-        # Commit changes after removing sensitive files with original message
+        # Create a new orphan branch to avoid action history
+        git checkout --orphan temp-deploy
+        
+        # Add all files (sensitive files already removed)
         git add -A
-        git commit --amend -m "$ORIGINAL_MSG" --no-edit
+        
+        # Commit with original message
+        git commit -m "$ORIGINAL_MSG"
         
         # Push to main branch in public repository
         echo "Pushing to main branch in public repository..."
         git remote add public https://x-access-token:${{ inputs.public-repo-token }}@github.com/${{ inputs.public-repo }}.git
-        git push public HEAD:main --force
+        git push public temp-deploy:main --force
         
         # Deploy to GitHub Pages directly from private repository
         cd ..
@@ -245,14 +250,19 @@ runs:
         # Get original commit message
         $originalMsg = git log -1 --pretty=%B
         
-        # Commit changes after removing sensitive files with original message
+        # Create a new orphan branch to avoid action history
+        git checkout --orphan temp-deploy
+        
+        # Add all files (sensitive files already removed)
         git add -A
-        git commit --amend -m $originalMsg --no-edit
+        
+        # Commit with original message
+        git commit -m $originalMsg
         
         # Push to main branch in public repository
         Write-Host "Pushing to main branch in public repository..."
         git remote add public https://x-access-token:${{ inputs.public-repo-token }}@github.com/${{ inputs.public-repo }}.git
-        git push public HEAD:main --force
+        git push public temp-deploy:main --force
         
         # Deploy to GitHub Pages directly from private repository
         cd ..

--- a/test/workflow/action.test.ts
+++ b/test/workflow/action.test.ts
@@ -153,12 +153,16 @@ describe('GitHub Action Workflow', () => {
       const powershellStep = actionConfig.runs.steps[2]
 
       // Check that sensitive files are removed before pushing to main
-      expect(bashStep.run).toMatch(/# Remove sensitive files[\s\S]*git push public HEAD:main --force/)
-      expect(powershellStep.run).toMatch(/# Remove sensitive files[\s\S]*git push public HEAD:main --force/)
+      expect(bashStep.run).toMatch(/# Remove sensitive files[\s\S]*git push public temp-deploy:main --force/)
+      expect(powershellStep.run).toMatch(/# Remove sensitive files[\s\S]*git push public temp-deploy:main --force/)
+      
+      // Check that orphan branch is created to avoid action history
+      expect(bashStep.run).toMatch(/git checkout --orphan temp-deploy/)
+      expect(powershellStep.run).toMatch(/git checkout --orphan temp-deploy/)
       
       // Check that original commit message is preserved
-      expect(bashStep.run).toMatch(/git commit --amend -m "\$ORIGINAL_MSG" --no-edit/)
-      expect(powershellStep.run).toMatch(/git commit --amend -m \$originalMsg --no-edit/)
+      expect(bashStep.run).toMatch(/git commit -m "\$ORIGINAL_MSG"/)
+      expect(powershellStep.run).toMatch(/git commit -m \$originalMsg/)
     })
 
     it('should deploy to GitHub Pages', () => {


### PR DESCRIPTION
## Summary
- GitHub Actionsの実行履歴がpublicリポジトリに残る問題を修正
- orphanブランチ（`temp-deploy`）を使用して履歴を切り離してプッシュ
- privateリポジトリのコミット履歴がpublicリポジトリに漏洩しないよう改善

## Changes
- `git commit --amend`の代わりに`git checkout --orphan temp-deploy`を使用
- 新しい履歴でコミットを作成し、`temp-deploy:main`でpublicリポジトリにプッシュ
- BashとPowerShellの両方の実装を更新
- テストを新しい実装に合わせて更新

## Test plan
- [x] ユニットテストが全てパス
- [ ] 実際のGitHub Actionsでの動作確認
- [ ] publicリポジトリにAction履歴が残らないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)