### PR TITLE
fix: GitHub ActionsワークフローとWindows環境での実行エラーを修正

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,6 +123,14 @@ runs:
         # Add all files (sensitive files and .github already removed)
         git add -A
         
+        # Check if there are files to commit
+        if git diff --cached --quiet; then
+          echo "No files to commit. Repository might be empty."
+          # Force add at least one file
+          echo "# Deployed from private repository" > README.md
+          git add README.md
+        fi
+        
         # Commit with original message
         git commit -m "$ORIGINAL_MSG"
         
@@ -299,6 +307,15 @@ runs:
         
         # Add all files (sensitive files and .github already removed)
         git add -A
+        
+        # Check if there are files to commit
+        $hasChanges = git diff --cached --quiet; $lastExitCode -ne 0
+        if (-not $hasChanges) {
+          Write-Host "No files to commit. Repository might be empty."
+          # Force add at least one file
+          "# Deployed from private repository" | Out-File README.md
+          git add README.md
+        }
         
         # Commit with original message
         git commit -m $originalMsg

--- a/action.yml
+++ b/action.yml
@@ -108,8 +108,8 @@ runs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
         
-        # Get original commit message
-        ORIGINAL_MSG=$(git log -1 --pretty=%B)
+        # Get original commit message (single line to avoid issues)
+        ORIGINAL_MSG=$(git log -1 --pretty=%s)
         
         # Create a new orphan branch to avoid action history
         git checkout --orphan temp-deploy
@@ -289,8 +289,8 @@ runs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
         
-        # Get original commit message
-        $originalMsg = git log -1 --pretty=%B
+        # Get original commit message (single line to avoid issues)
+        $originalMsg = git log -1 --pretty=%s
         
         # Create a new orphan branch to avoid action history
         git checkout --orphan temp-deploy

--- a/action.yml
+++ b/action.yml
@@ -318,7 +318,7 @@ runs:
         }
         
         # Commit with original message
-        git commit -m $originalMsg
+        git commit -m "$originalMsg"
         
         # Push to a new branch in public repository
         Write-Host "Pushing to a new branch in public repository..."


### PR DESCRIPTION
## 修正内容

### 1. YAML構文エラーの修正
- `action.yml`の複数行文字列が正しくフォーマットされていなかった問題を修正
- PR作成時のbodyパラメータをecho -eで処理するよう変更

### 2. Windows環境でのVitest実行エラーの解決
- `vitest.config.ts`にroot設定を追加
- PowerShellとnpm経由での実行時のパス解決の違いに対応

### 3. orphanブランチ作成時のエラー修正
- 空のリポジトリでコミットしようとした際のエラーを回避
- ファイルが存在しない場合はREADME.mdを作成してコミット

### 4. コミットメッセージのエラー修正
- 複数行のコミットメッセージによるエラーを回避（`--pretty=%s`を使用）
- PowerShellスクリプトでコミットメッセージを引用符で囲むよう修正

### 5. ワークフロー権限の追加
- `.github/workflows/test.yml`にpull-requests権限を追加

これらの修正により、GitHub Actionsワークフローが正常に動作するようになります。